### PR TITLE
[variants] Rename type to archlinux

### DIFF
--- a/arkdep-build.d/test-manjaro-cosmic/type
+++ b/arkdep-build.d/test-manjaro-cosmic/type
@@ -1,1 +1,1 @@
-manjaro
+archlinux

--- a/arkdep-build.d/test-manjaro-gnome/type
+++ b/arkdep-build.d/test-manjaro-gnome/type
@@ -1,1 +1,1 @@
-manjaro
+archlinux

--- a/arkdep-build.d/test-manjaro-kde/type
+++ b/arkdep-build.d/test-manjaro-kde/type
@@ -1,1 +1,1 @@
-manjaro
+archlinux

--- a/arkdep-build.d/test-manjaro-xfce/type
+++ b/arkdep-build.d/test-manjaro-xfce/type
@@ -1,1 +1,1 @@
-manjaro
+archlinux


### PR DESCRIPTION
This will restore compatibility with upstream.

Closes https://github.com/manjaro/arkdep-variants/issues/10